### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/TeamAtlasDev/horizon-website/security/code-scanning/7](https://github.com/TeamAtlasDev/horizon-website/security/code-scanning/7)

Add an explicit `permissions` block for the `build` job in `.github/workflows/deploy.yml`, setting `contents: read` as the minimal required scope for checkout and build-related read operations. Keep existing functionality unchanged by not altering steps, triggers, or the already-correct `deploy` job permissions.

Best single fix in this snippet: insert under `build:` (before `name`/`runs-on`) the following:

```yml
permissions:
  contents: read
```

This scopes `GITHUB_TOKEN` for `build` to read-only repository contents while preserving current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
